### PR TITLE
Disable APM registries for Geth nodes

### DIFF
--- a/build/server/src/fetchers/fetchIsNodeGeth.ts
+++ b/build/server/src/fetchers/fetchIsNodeGeth.ts
@@ -1,0 +1,11 @@
+import getClientVersion from "../web3/getClientVersion";
+
+/**
+ * Checks if the Ethereum client connected to is Geth
+ */
+export default async function fetchIsNodeGeth(): Promise<boolean> {
+  // "Parity-Ethereum//v2.5.10-stable-9f94473ea-20191112/x86_64-linux-musl/rustc1.38.0"
+  // "Geth/v1.9.8-stable-d62e9b28/linux-amd64/go1.13.4"
+  const clientVersion = await getClientVersion();
+  return /^geth/i.test(clientVersion);
+}

--- a/build/server/src/web3/getClientVersion.ts
+++ b/build/server/src/web3/getClientVersion.ts
@@ -1,0 +1,12 @@
+import provider from "./provider";
+
+/**
+ * Gets the client version
+ *
+ * @returns clientVersion
+ * "Parity-Ethereum//v2.5.10-stable-9f94473ea-20191112/x86_64-linux-musl/rustc1.38.0"
+ * "Geth/v1.9.8-stable-d62e9b28/linux-amd64/go1.13.4"
+ */
+export default async function getClientVersion(): Promise<string> {
+  return await provider.send("web3_clientVersion", []);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - IPFS_CLUSTER_PORT=9094
       - IPFS_API_HOST=ipfs.dappnode
       - 'WEB3_HOST_URL=http://fullnode.dappnode:8545'
+      - IGNORE_REGISTRY_IF_GETH=true
       - LOG_LEVEL=
 volumes:
   data: {}


### PR DESCRIPTION
Also, adds ENV
```
IGNORE_REGISTRY_IF_GETH=true
```
so it can be turned off in case a solution is find