### PR TITLE
Fix server tests

### DIFF
--- a/build/server/src/utils/multiname.ts
+++ b/build/server/src/utils/multiname.ts
@@ -15,7 +15,8 @@ export const splitMultiname = (multiname: string): string[] =>
     .replace(/^\/+|\/+$/g, "")
     .split(separator)
     .filter(p => p)
-    .map(decodeURIComponent);
+    .map(decodeURIComponent)
+    .map(s => s.trim());
 
 export const parseType = (multiname: string): string =>
   splitMultiname(multiname)[0];

--- a/build/server/src/utils/multiname.ts
+++ b/build/server/src/utils/multiname.ts
@@ -15,8 +15,7 @@ export const splitMultiname = (multiname: string): string[] =>
     .replace(/^\/+|\/+$/g, "")
     .split(separator)
     .filter(p => p)
-    .map(decodeURIComponent)
-    .map(s => s.trim());
+    .map(s => decodeURIComponent(s).trim());
 
 export const parseType = (multiname: string): string =>
   splitMultiname(multiname)[0];

--- a/build/server/test/fetchers/fetchNewApmVersions.test.int.ts
+++ b/build/server/test/fetchers/fetchNewApmVersions.test.int.ts
@@ -44,17 +44,16 @@ describe("fetcher > fetchNewVersionsFromRepo", () => {
 
     it(`Should return all versions for ${repo.name}`, async () => {
       const versions = await fetchNewApmVersions(repoName, 10);
-
-      const expectedVersion210 = {
-        version: "2.1.0",
-        contentUri: "ipfs:QmQmv6Sx2XGDKtncqZPYz3skQjJtxCbcfuPyyDh8iHx2P3"
+      console.log("versions: ", versions);
+      const expectedVersion212 = {
+        version: "2.1.2",
+        contentUri: "ipfs:QmWyueP8dtXwuojHX4ThZJpggxxpyQYaGvDoHJa7dcPUrh"
       };
 
-      const version210 = versions.find(
-        ({ version }) => version === expectedVersion210.version
+      const version212 = versions.find(
+        ({ version }) => version === expectedVersion212.version
       );
-
-      expect(version210).to.deep.equal(expectedVersion210);
+      expect(version212).to.deep.equal(expectedVersion212);
     }).timeout(30 * 1000);
   });
 });


### PR DESCRIPTION
The function `fetchNewApmVersions` for the repo `finance.aragonpm.eth` does not obtain an object with a version 2.1.0 currently, it's outdated. It's possible this was removed. We have changed this value, and now we look for another version that exists.